### PR TITLE
Publish to PyPI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,30 @@
 version: 2
 jobs:
-  test:
+  test-2.7:
+    docker:
+      - image: circleci/python:2.7
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run: sudo pip install tox
+
+      - run: tox -e py27
+  test-3.5:
+    docker:
+      - image: circleci/python:3.5
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run: sudo pip install tox
+
+      - run: tox -e py35
+  test-3.6:
     docker:
       - image: circleci/python:3.6
 
@@ -11,10 +35,25 @@ jobs:
 
       - run: sudo pip install tox
 
-      - run: tox
+      - run: tox -e py36
+  test-3.7:
+    docker:
+      - image: circleci/python:3.7
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run: sudo pip install tox
+
+      - run: tox -e py37
 
 workflows:
   version: 2
   test:
     jobs:
-      - test
+      - test-2.7
+      - test-3.5
+      - test-3.6
+      - test-3.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,12 +63,24 @@ jobs:
 
 workflows:
   version: 2
-  test:
+  test-and-publish:
     jobs:
-      - test-2.7
-      - test-3.5
-      - test-3.6
-      - test-3.7
+      - test-2.7:
+          filters:
+            tags:
+              only: /^.*/
+      - test-3.5:
+          filters:
+            tags:
+              only: /^.*/
+      - test-3.6:
+          filters:
+            tags:
+              only: /^.*/
+      - test-3.7:
+          filters:
+            tags:
+              only: /^.*/
       - publish:
           requires:
             - test-2.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2
+jobs:
+  test:
+    docker:
+      - image: circleci/python:3.6
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run: pip install tox
+
+      - run: tox
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - checkout
 
-      - run: pip install tox
+      - run: sudo pip install tox
 
       - run: tox
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,18 @@ jobs:
       - run: sudo pip install tox
 
       - run: tox -e py37
+  publish:
+    docker:
+      - image: circleci/python:3.6
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - run: sudo pip install twine
+
+      - run: ./publish_to_pypi.sh
 
 workflows:
   version: 2
@@ -57,3 +69,13 @@ workflows:
       - test-3.5
       - test-3.6
       - test-3.7
+      - publish:
+          requires:
+            - test-2.7
+            - test-3.5
+            - test-3.6
+            - test-3.7
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*/
+          context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,19 +68,19 @@ workflows:
       - test-2.7:
           filters:
             tags:
-              only: /^.*/
+              only: /.*/
       - test-3.5:
           filters:
             tags:
-              only: /^.*/
+              only: /.*/
       - test-3.6:
           filters:
             tags:
-              only: /^.*/
+              only: /.*/
       - test-3.7:
           filters:
             tags:
-              only: /^.*/
+              only: /.*/
       - publish:
           requires:
             - test-2.7
@@ -90,4 +90,6 @@ workflows:
           filters:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/
           context: org-global

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*$py.class
+
+.tox/
+MANIFEST

--- a/bin/create_migration.py
+++ b/bin/create_migration.py
@@ -4,6 +4,7 @@
 import optparse
 import os
 from datetime import datetime
+import logging
 
 DEFAULT_MIGRATION_PATH = "migrations"
 VERSION_FORMAT = "%Y%m%d%H%M%S"
@@ -34,6 +35,10 @@ class TestMigration(unittest.TestCase):
 
 
 def main():
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)s:%(module)s:%(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S%z", level=logging.INFO)
+
     parser = optparse.OptionParser(description="Run data migrations.")
     parser.add_option(
         "-p", "--path", dest="path", default=DEFAULT_MIGRATION_PATH,
@@ -58,20 +63,20 @@ def _generate_migration(path, description, new_migration):
 
     test_name = "{0}/migrations/test_{1}.py".format(test_path, base_name)
 
-    if os.path.isdir(os.path.join(path)) == False:
+    if os.path.isdir(os.path.join(path)) is False:
         os.mkdir(os.path.join(path))
 
-    if os.path.isdir(os.path.join(test_path, path)) == False:
+    if os.path.isdir(os.path.join(test_path, path)) is False:
         os.mkdir(os.path.join(test_path, path))
 
     if new_migration:
         with open(name, "w") as migration_file:
             migration_file.write(MIGRATION_TEMPLATE)
-            print " ".join(("Migration:\n", name, "created!"))
+            logging.info(" ".join(("Migration:\n", name, "created!")))
 
         with open(test_name, "w") as migration_file:
             migration_file.write(MIGRATION_TEST_TEMPLATE.format(base_name))
-            print " ".join(("Test:\n", test_name, "created!"))
+            logging.info(" ".join(("Test:\n", test_name, "created!")))
 
 
 if __name__ == "__main__":

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,0 @@
-machine:
-  services:
-    - cassandra
-
-dependencies:
-  pre:
-    - pip install -r dev-requirements.txt

--- a/publish_to_pypi.sh
+++ b/publish_to_pypi.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+
+is_package_installed() {
+    python -c "import $1";
+}
+
+die() {
+    echo "$1. Deployment failed.";
+
+    exit 2;
+}
+
+
+[ -n "$PYPI_USERNAME" ] || die '$PYPI_USERNAME is required';
+
+[ -n "$PYPI_PASSWORD" ] || die '$PYPI_PASSWORD is required';
+
+if ! is_package_installed twine; then
+    echo 'Installing twine';
+    pip install twine || die 'Twine failed to install';
+fi
+
+python setup.py sdist || die 'setup.py sdist failed'
+
+twine upload --username $PYPI_USERNAME --password $PYPI_PASSWORD dist/* ||  die 'Twine upload failed';

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,15 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except:
+    from distutils.core import setup
+
+
 setup(
     name='armus',
     packages=['armus'],
     scripts=['bin/create_migration.py'],
-    version='0.1',
+    version='0.2.0',
     description='A tool for running migrations',
     author='uStudio',
     author_email='dev@ustudio.com',
-    url='https://github.com/ustudio/armus',
-    download_url='https://github.com/ustudio/armus/archive/0.1.tar.gz',
-    keywords=[],
-    classifiers=[],
-)
+    url='https://github.com/ustudio/armus')

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,5 +1,9 @@
 import unittest
-from mock import patch, MagicMock
+
+try:
+    from unittest.mock import patch, MagicMock
+except ImportError:
+    from mock import patch, MagicMock
 
 from armus.migrations import apply_new, revert_last
 
@@ -93,7 +97,8 @@ class TestApplyNewMigrations(unittest.TestCase):
             mock_listdir.return_value = test_directory_listing
             mock_import_module.return_value = some_module
 
-            reverted_migration = revert_last("/this/is/some/path", pre_revert_migrations, test="test")
+            reverted_migration = revert_last(
+                "/this/is/some/path", pre_revert_migrations, test="test")
 
             mock_import_module.return_value.down.assert_called_with(test="test")
             self.assertEqual(expected_migration, reverted_migration)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27
+envlist = py27, py35, py36, py37
 
 [testenv]
 commands = nosetests

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27
+
+[testenv]
+commands = nosetests
+deps =
+    nose
+
+[testenv:py27]
+deps =
+    nose
+    mock


### PR DESCRIPTION
This PR switches the project to CircleCI 2.0, updates the code to work with Python 3, and adds a CircleCI job to automatically publish version tags to PyPI.

I configured the CircleCI jobs to run the tests via Tox to encourage maintainers to also run the tests locally via Tox. It isn't strictly necessary for CircleCI to use Tox since the workflow is already split into one job per Python version, but it means there is a little less duplication of commands amongst the jobs. Also, the overhead of installing Tox is negligible (usually 1 second or less).

@ustudio/reviewers Please review