### PR TITLE
Use Project-Specific CircleCI Context for PyPI Publish Credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,4 +92,4 @@ workflows:
               only: /^v[0-9]+(\.[0-9]+)*/
             branches:
               ignore: /.*/
-          context: org-global
+          context: armus-publisher


### PR DESCRIPTION
This PR updates the CircleCI config to use a project-specific context for publish credentials so that managing the credentials is easier.

Note that we will not be publishing a new version of the package because the code did not change.

@ustudio/reviewers Please review